### PR TITLE
Feature add dependencies edit command

### DIFF
--- a/src/NupkgWrench/Constants.cs
+++ b/src/NupkgWrench/Constants.cs
@@ -1,4 +1,4 @@
-﻿namespace NupkgWrench
+namespace NupkgWrench
 {
     internal class Constants
     {
@@ -18,5 +18,15 @@
 
         internal const string SinglePackageRootDesc = "Path to a package, directory containing, or a file globbing pattern that resolves to a single package (ex: path/**/*.nupkg).";
         internal const string MultiplePackagesRootDesc = "Paths to individual packages, directories containing packages, or file globbing patterns (ex: path/**/*.nupkg). Multiple values may be passed in.";
+
+        internal const string FrameworkOptionTemplate = "-f|--framework";
+        internal const string FrameworkOptionDesc = "Group target frameworks. Use 'any' for the default group. If not specified all dependencies are processed.";
+
+        internal const string EditTypeTemplate = "-t|--type";
+        internal const string EditTypeDesc = "Edit type, such as (add/remove/modify).";
+
+        internal const string EditExcludeTemplate = "-x|--exclude";
+        internal const string EditExcludeDesc = "Edit dependency exclude attribute, example: Build,Analyzers.";
+
     }
 }

--- a/src/NupkgWrench/NupkgWrench.csproj
+++ b/src/NupkgWrench/NupkgWrench.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(FileSystemGlobbingVersion)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System.IO.Compression" />
+    <!--<Reference Include="System.IO.Compression" />-->
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/NupkgWrench/NuspecCommands/DependenciesCommand.cs
+++ b/src/NupkgWrench/NuspecCommands/DependenciesCommand.cs
@@ -11,6 +11,7 @@ namespace NupkgWrench
 
             DependenciesClearCommand.Register(parentCommand, log);
             DependenciesEmptyGroupCommand.Register(parentCommand, log);
+            DependenciesEditCommand.Register(parentCommand, log);
         }
 
         private static void Run(CommandLineApplication cmd, ILogger log)

--- a/src/NupkgWrench/NuspecCommands/DependenciesEditCommand.cs
+++ b/src/NupkgWrench/NuspecCommands/DependenciesEditCommand.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using McMaster.Extensions.CommandLineUtils;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+
+namespace NupkgWrench
+{
+    internal static class DependenciesEditCommand
+    {
+        public static void Register(CommandLineApplication cmdApp, ILogger log)
+        {
+            cmdApp.Command("edit", cmd => Run(cmd, log));
+        }
+
+        private static void Run(CommandLineApplication cmd, ILogger log)
+        {
+            cmd.Description = "Edit all dependencies or set of target framework group dependencies.";
+
+            var idFilter = cmd.Option(Constants.IdFilterTemplate, Constants.IdFilterDesc, CommandOptionType.SingleValue);
+            var versionFilter = cmd.Option(Constants.VersionFilterTemplate, Constants.VersionFilterDesc, CommandOptionType.SingleValue);
+            var frameworkOption = cmd.Option(Constants.FrameworkOptionTemplate, Constants.FrameworkOptionDesc, CommandOptionType.MultipleValue);
+
+            var editType = cmd.Option(Constants.EditTypeTemplate, Constants.EditTypeDesc, CommandOptionType.SingleValue);
+            var editExclude = cmd.Option(Constants.EditExcludeTemplate, Constants.EditExcludeDesc, CommandOptionType.SingleValue);
+
+            var argRoot = cmd.Argument(
+                "[root]",
+                Constants.MultiplePackagesRootDesc,
+                true);
+
+            cmd.HelpOption(Constants.HelpOption);
+
+            cmd.OnExecute(() =>
+            {
+                try
+                {
+                    var inputs = argRoot.Values;
+
+                    if (inputs.Count < 1)
+                    {
+                        inputs.Add(Directory.GetCurrentDirectory());
+                    }
+
+                    var editForFrameworks = new HashSet<NuGetFramework>();
+
+                    if (frameworkOption.HasValue())
+                    {
+                        foreach (var option in frameworkOption.Values)
+                        {
+                            var nugetFramework = NuGetFramework.Parse(option);
+
+                            log.LogInformation($"editing dependencies for {nugetFramework.GetShortFolderName()}");
+
+                            editForFrameworks.Add(nugetFramework);
+                        }
+                    }
+
+                    if (!editType.HasValue())
+                    {
+                        log.LogError("please provider edit verb option.");
+                        return 1;
+                    }
+
+                    if (!Enum.TryParse(editType.Value(), true, out EditType verb))
+                    {
+                        log.LogError($"incorrect edit verb: {editType.Value()}.");
+                        return 1;
+                    }
+
+                    if (!idFilter.HasValue())
+                    {
+                        log.LogError("please provider id option.");
+                        return 1;
+                    }
+
+                    if (!versionFilter.HasValue())
+                    {
+                        log.LogError("please provider version option.");
+                        return 1;
+                    }
+
+                    var version = versionFilter.Value();
+                    var exclude = editExclude.HasValue() ? editExclude.Value() : null;
+
+                    var packages = Util.GetPackagesWithFilter(null, null, false, false, inputs.ToArray());
+
+                    foreach (var package in packages)
+                    {
+                        var id = idFilter.Value();
+
+                        log.LogMinimal($"processing {package}");
+
+                        // Get nuspec file path
+                        string nuspecPath;
+                        XDocument nuspecXml;
+                        using (var packageReader = new PackageArchiveReader(package))
+                        {
+                            nuspecPath = packageReader.GetNuspecFile();
+                            nuspecXml = XDocument.Load(packageReader.GetNuspec());
+                        }
+
+                        var metadata = Util.GetMetadataElement(nuspecXml);
+                        var nameNamespaceName = metadata.Name.NamespaceName;
+                        var dependenciesNode = metadata.Element(XName.Get("dependencies", nameNamespaceName));
+
+                        if (dependenciesNode != null)
+                        {
+                            var groups = dependenciesNode.Elements(XName.Get("group", nameNamespaceName)).ToList();
+                            if (editForFrameworks.Count < 1)
+                            {
+                                if (groups.Count > 0)
+                                {
+                                    foreach (var element in groups)
+                                    {
+                                        Process(element, verb, id, version, nameNamespaceName, exclude);
+                                    }
+                                }
+                                else
+                                {
+                                    Process(dependenciesNode, verb, id, version, nameNamespaceName, exclude);
+                                }
+                            }
+                            else
+                            {
+                                foreach (var editForFramework in editForFrameworks)
+                                {
+                                    if (editForFramework.IsAny)
+                                    {
+                                        if (groups.Count > 0)
+                                        {
+                                            foreach (var element in groups)
+                                            {
+                                                // Process groups with no tfm
+                                                Process(element, verb, id, version, nameNamespaceName, exclude);
+                                            }
+                                        }
+                                        else
+                                        {
+                                            // Process non-group items
+                                            Process(dependenciesNode, verb, id, version, nameNamespaceName, exclude);
+                                        }
+                                    }
+                                    else
+                                    {
+                                        foreach (var node in groups)
+                                        {
+                                            var targetFramework = node.Attribute(XName.Get("targetFramework"))?.Value;
+
+                                            if (!string.IsNullOrEmpty(targetFramework))
+                                            {
+                                                var framework = NuGetFramework.Parse(targetFramework);
+
+                                                if (framework.Equals(editForFramework))
+                                                {
+                                                    Process(node, verb, id, version, nameNamespaceName, exclude);
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Update zip
+                            Util.AddOrReplaceZipEntry(package, nuspecPath, nuspecXml, log);
+                        }
+                    }
+
+                    return 0;
+                }
+                catch (Exception ex)
+                {
+                    log.LogError(ex.Message);
+                    log.LogError(ex.ToString());
+                }
+
+                return 1;
+            });
+        }
+
+        private static void Process(XContainer dependencies, EditType type, string id, string version, string nameNamespaceName, string exclude)
+        {
+            var idXName = XName.Get("id");
+            var versionXName = XName.Get("version");
+            var excludeXName = XName.Get("exclude");
+            var dependency = dependencies?.Elements(XName.Get("dependency", nameNamespaceName))
+                .FirstOrDefault(e => string.Equals(e.Attribute(idXName)?.Value, id, StringComparison.OrdinalIgnoreCase));
+            switch (type)
+            {
+                case EditType.Add:
+                case EditType.Modify:
+                    if (dependency != null)
+                    {
+                        dependency.SetAttributeValue(versionXName, version);
+                        if (exclude != null)
+                        {
+                            dependency.SetAttributeValue(excludeXName, exclude);
+                        }
+                        else
+                        {
+                            dependency.Attribute(excludeXName)
+                                ?.Remove();
+                        }
+                    }
+                    else if (dependencies != null)
+                    {
+                        dependency = new XElement(XName.Get("dependency", nameNamespaceName));
+                        dependency.SetAttributeValue(idXName, id);
+                        dependency.SetAttributeValue(versionXName, version);
+                        if (exclude != null)
+                        {
+                            dependency.SetAttributeValue(excludeXName, exclude);
+                        }
+                        dependencies.AddFirst(dependency);
+                    }
+                    break;
+                case EditType.Remove:
+                    dependency?.Remove();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type), type, null);
+            }
+        }
+    }
+
+    public enum EditType
+    {
+        Add,
+        Modify,
+        Remove
+    }
+}


### PR DESCRIPTION
dependencies edit command, support `add/remove/modify`.
see command : NupkgWrench nuspec dependencies edit -h

```command
# add dependency Command 1.0.0.0 to every group dependencies
NupkgWrench sample.nupkg nuspec dependencies edit -t add -i Common -v 1.0.0.0

# add dependency Command 1.0.0.0 to net45 group dependencies
NupkgWrench sample.nupkg nuspec dependencies edit -t add -i Common -v 1.0.0.0 -f net45

# remove dependency Command 1.0.0.0 from every group dependencies
NupkgWrench sample.nupkg nuspec dependencies edit -t add -i Common -v 1.0.0.0

# remove dependency Command 1.0.0.0 from net45 group dependencies
NupkgWrench sample.nupkg nuspec dependencies edit -t add -i Common -v 1.0.0.0 -f net45
```